### PR TITLE
Fix backend bug batch ahead of 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- The `overdue_tasks` attribute on `sensor.tasks_overdue` listed every enabled task instead of only the overdue ones ([#20](https://github.com/henriquekraemer/intellikeep/issues/20)).
+- Completing a yearly recurring task on Feb 29 raised an error when scheduling the next occurrence ([#20](https://github.com/henriquekraemer/intellikeep/issues/20)).
+- Tasks now become overdue the day after their due date. Previously there was an undocumented one-day grace period where a task past its due date still reported as due ([#20](https://github.com/henriquekraemer/intellikeep/issues/20)).
+- The "Notify Days Before" default from the integration options is now applied to tasks created without an explicit value ([#20](https://github.com/henriquekraemer/intellikeep/issues/20)).
+- The sidebar panel is removed when the integration unloads, so reloading after an options change re-registers it cleanly ([#20](https://github.com/henriquekraemer/intellikeep/issues/20)).
+
+### Added
+
+- New `intellikeep_task_updated` event fired on every task mutation (`created`, `updated`, `completed`, `reopened`, `deleted`, `note_added`, `note_deleted`), usable as an automation trigger ([#20](https://github.com/henriquekraemer/intellikeep/issues/20)).
+
+### Changed
+
+- Lovelace card resource registration now waits for Home Assistant to finish starting instead of using a fixed delay ([#20](https://github.com/henriquekraemer/intellikeep/issues/20)).
+
 ## [1.0.2] - 2026-04-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,5 +103,5 @@ Two separate systems: the backend uses `strings.json` + `translations/{en,es,pt}
 - **No external Python dependencies** — Uses only HA core APIs (`voluptuous`, `homeassistant.helpers`).
 - **Requires HA 2026.1.0+**
 - **Version is duplicated** — bump `manifest.json`, `const.py` (`VERSION`, served to the frontend via the `get_version` WebSocket command), and `panel/package.json` together when releasing; update `CHANGELOG.md`.
-- **HA bus events** — `intellikeep_task_notification` (fired by the notification manager; documented automation hook) and `intellikeep_task_updated` (pushes live updates to panel/card subscriptions).
+- **HA bus events** — `intellikeep_task_notification` is fired by the notification manager (documented automation hook). `intellikeep_task_updated` is fired by `TaskManager` on every mutation (`created`, `updated`, `completed`, `reopened`, `deleted`, `note_added`, `note_deleted`). Panel/card live updates flow through coordinator listeners via the `subscribe` WebSocket command, not through these events.
 - **CI/CD** — GitHub Actions runs pytest on Python 3.12 & 3.13 (push to `main`/`dev` and PRs), plus HACS validation, a frontend build, and `hassfest` on `main` pushes/PRs.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Intellilar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/custom_components/intellikeep/__init__.py
+++ b/custom_components/intellikeep/__init__.py
@@ -16,6 +16,8 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import (
     CONF_NOTIFICATION_SERVICE,
+    CONF_NOTIFY_DAYS_BEFORE_DEFAULT,
+    DEFAULT_NOTIFY_DAYS_BEFORE,
     DOMAIN,
     PANEL_ICON,
     PANEL_TITLE,
@@ -25,7 +27,7 @@ from .const import (
 from .coordinator import IntelliKeepCoordinator
 from .frontend import async_register_frontend
 from .notifications import NotificationManager
-from .services import async_register_services, async_unregister_services
+from .services import async_register_services
 from .runtime_data import IntelliKeepConfigEntry, IntelliKeepRuntimeData
 from .storage import IntelliKeepStorage
 from .task_manager import TaskManager
@@ -71,11 +73,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: IntelliKeepConfigEntry) 
     )
     notification_manager.start()
 
+    notify_days_before_default = entry.options.get(
+        CONF_NOTIFY_DAYS_BEFORE_DEFAULT,
+        entry.data.get(CONF_NOTIFY_DAYS_BEFORE_DEFAULT, DEFAULT_NOTIFY_DAYS_BEFORE),
+    )
     runtime_data = IntelliKeepRuntimeData(
         storage=storage,
         task_manager=task_manager,
         coordinator=coordinator,
         notification_manager=notification_manager,
+        notify_days_before_default=int(notify_days_before_default),
     )
     entry.runtime_data = runtime_data
     hass.data[DOMAIN][entry.entry_id] = runtime_data
@@ -108,6 +115,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: IntelliKeepConfigEntry)
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+        _async_remove_panel(hass)
 
     return unload_ok
 
@@ -147,3 +155,13 @@ async def _async_register_panel(hass: HomeAssistant) -> None:
         )
     except Exception as err:  # noqa: BLE001
         _LOGGER.warning("Could not register IntelliKeep panel: %s", err)
+
+
+def _async_remove_panel(hass: HomeAssistant) -> None:
+    """Remove the sidebar panel so a reload can re-register it cleanly."""
+    from homeassistant.components import frontend as ha_frontend  # noqa: PLC0415
+
+    try:
+        ha_frontend.async_remove_panel(hass, PANEL_URL)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("Could not remove IntelliKeep panel: %s", err)

--- a/custom_components/intellikeep/coordinator.py
+++ b/custom_components/intellikeep/coordinator.py
@@ -33,9 +33,11 @@ class IntelliKeepCoordinator(DataUpdateCoordinator[dict]):
     async def _async_update_data(self) -> dict:
         """Aggregate task stats for sensor entities."""
         all_tasks = self.task_manager._storage.get_all_tasks()
+        overdue_tasks = self.task_manager.get_overdue_tasks()
         return {
             "all_tasks": all_tasks,
             "tasks_due_count": len(self.task_manager.get_tasks_due_today()),
-            "tasks_overdue_count": len(self.task_manager.get_overdue_tasks()),
+            "tasks_overdue_count": len(overdue_tasks),
+            "overdue_tasks": overdue_tasks,
             "next_due_task": self.task_manager.get_next_due_task(),
         }

--- a/custom_components/intellikeep/frontend/__init__.py
+++ b/custom_components/intellikeep/frontend/__init__.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import logging
-import os
 from pathlib import Path
 
 from homeassistant.components import frontend as ha_frontend
 from homeassistant.components.http import StaticPathConfig
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.event import async_call_later
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, Event, HomeAssistant, callback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ async def async_register_frontend(hass: HomeAssistant, component_domain: str) ->
 def _async_register_card_resource(hass: HomeAssistant, component_domain: str) -> None:
     """Add the card JS as a Lovelace resource (if lovelace is available)."""
 
-    async def _do_register(_now=None) -> None:
+    async def _do_register(_event: Event | None = None) -> None:
         try:
             lovelace = hass.data.get("lovelace")
             if lovelace is None:
@@ -65,5 +64,9 @@ def _async_register_card_resource(hass: HomeAssistant, component_domain: str) ->
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Could not register Lovelace card resource: %s", err)
 
-    # Defer until HA has finished starting so Lovelace data is available
-    async_call_later(hass, 2, _do_register)
+    # Defer until HA has finished starting so Lovelace data is available;
+    # if the entry is set up at runtime (after startup), register immediately.
+    if hass.state is CoreState.running:
+        hass.async_create_task(_do_register())
+    else:
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _do_register)

--- a/custom_components/intellikeep/notifications.py
+++ b/custom_components/intellikeep/notifications.py
@@ -133,7 +133,7 @@ class NotificationManager:
                     {"title": title, "message": message},
                     blocking=False,
                 )
-            except (ValueError, Exception) as err:
+            except Exception as err:  # noqa: BLE001
                 _LOGGER.warning(
                     "Failed to call notification service %s: %s",
                     self.notification_service,

--- a/custom_components/intellikeep/runtime_data.py
+++ b/custom_components/intellikeep/runtime_data.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from homeassistant.config_entries import ConfigEntry
 
+from .const import DEFAULT_NOTIFY_DAYS_BEFORE
 from .coordinator import IntelliKeepCoordinator
 from .notifications import NotificationManager
 from .storage import IntelliKeepStorage
@@ -19,6 +20,7 @@ class IntelliKeepRuntimeData:
     task_manager: TaskManager
     coordinator: IntelliKeepCoordinator
     notification_manager: NotificationManager
+    notify_days_before_default: int = DEFAULT_NOTIFY_DAYS_BEFORE
 
 
 type IntelliKeepConfigEntry = ConfigEntry[IntelliKeepRuntimeData]

--- a/custom_components/intellikeep/sensor.py
+++ b/custom_components/intellikeep/sensor.py
@@ -82,8 +82,7 @@ class IntelliKeepOverdueCountSensor(_IntelliKeepSensorBase):
                 "due_date": t.due_date.isoformat() if t.due_date else None,
                 "priority": str(t.priority),
             }
-            for t in (self.coordinator.data.get("all_tasks") or [])
-            if not t.enabled is False
+            for t in (self.coordinator.data.get("overdue_tasks") or [])
         ]
         return {"overdue_tasks": overdue} if overdue else None
 

--- a/custom_components/intellikeep/services.py
+++ b/custom_components/intellikeep/services.py
@@ -68,6 +68,8 @@ def async_register_services(
         coordinator = runtime_data.coordinator
         data = _coerce_int_fields(dict(call.data), "custom_days_interval", "notify_days_before")
         data = _coerce_due_date(data)
+        if "notify_days_before" not in data:
+            data["notify_days_before"] = runtime_data.notify_days_before_default
         if "priority" in data:
             data["priority"] = TaskPriority(data["priority"])
         if "frequency" in data:

--- a/custom_components/intellikeep/task_manager.py
+++ b/custom_components/intellikeep/task_manager.py
@@ -1,6 +1,7 @@
 """Business logic for IntelliKeep task management."""
 from __future__ import annotations
 
+import calendar
 import logging
 from datetime import datetime, timedelta
 from typing import Any
@@ -8,6 +9,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
+from .const import EVENT_TASK_UPDATED
 from .models import Task, TaskActivity, TaskActivityType, TaskExecution, TaskNote, TaskFrequency, TaskStatus
 from .storage import IntelliKeepStorage
 
@@ -66,6 +68,12 @@ class TaskManager:
         self.hass = hass
         self._storage = storage
 
+    def _fire_task_updated(self, task_id: str, action: str) -> None:
+        """Fire intellikeep_task_updated so users can build automations on changes."""
+        self.hass.bus.async_fire(
+            EVENT_TASK_UPDATED, {"task_id": task_id, "action": action}
+        )
+
     # ------------------------------------------------------------------
     # CRUD
     # ------------------------------------------------------------------
@@ -75,6 +83,7 @@ class TaskManager:
         task = Task(**kwargs)
         self._storage.upsert_task(task)
         await self._storage.async_save()
+        self._fire_task_updated(task.task_id, "created")
         _LOGGER.debug("Created task %s (%s)", task.task_id, task.name)
         return task
 
@@ -109,6 +118,7 @@ class TaskManager:
             ))
         self._storage.upsert_task(task)
         await self._storage.async_save()
+        self._fire_task_updated(task_id, "updated")
         return task
 
     async def async_complete_task(
@@ -178,6 +188,7 @@ class TaskManager:
                 )
 
         await self._storage.async_save()
+        self._fire_task_updated(task_id, "completed")
         _LOGGER.debug("Completed task %s by %s", task_id, completed_by or "unknown")
         return task
 
@@ -201,6 +212,7 @@ class TaskManager:
         task.updated_at = dt_util.utcnow()
         self._storage.upsert_task(task)
         await self._storage.async_save()
+        self._fire_task_updated(task_id, "note_added")
         _LOGGER.debug("Added note to task %s", task_id)
         return note
 
@@ -225,6 +237,7 @@ class TaskManager:
         task.updated_at = dt_util.utcnow()
         self._storage.upsert_task(task)
         await self._storage.async_save()
+        self._fire_task_updated(task_id, "note_deleted")
         _LOGGER.debug("Deleted note %s from task %s", note_id, task_id)
         return True
 
@@ -243,6 +256,7 @@ class TaskManager:
         ))
         self._storage.upsert_task(task)
         await self._storage.async_save()
+        self._fire_task_updated(task_id, "reopened")
         _LOGGER.debug("Reopened task %s", task_id)
         return task
 
@@ -250,6 +264,7 @@ class TaskManager:
         deleted = self._storage.delete_task(task_id)
         if deleted:
             await self._storage.async_save()
+            self._fire_task_updated(task_id, "deleted")
             _LOGGER.debug("Deleted task %s", task_id)
         return deleted
 
@@ -264,9 +279,9 @@ class TaskManager:
         if task.due_date is None:
             return TaskStatus.PENDING
         days_until_due = (task.due_date.date() - now.date()).days
-        if days_until_due < -1:
+        if days_until_due < 0:
             return TaskStatus.OVERDUE
-        if days_until_due <= 0:
+        if days_until_due == 0:
             return TaskStatus.DUE
         return TaskStatus.PENDING
 
@@ -331,12 +346,14 @@ class TaskManager:
                 month = base.month % 12 + 1
                 year = base.year + (1 if base.month == 12 else 0)
                 # Handle months shorter than current day (e.g. Jan 31 → Feb 28)
-                import calendar
                 last_day = calendar.monthrange(year, month)[1]
                 day = min(base.day, last_day)
                 return base.replace(year=year, month=month, day=day)
             case TaskFrequency.YEARLY:
-                return base.replace(year=base.year + 1)
+                # Handle Feb 29 when the next year is not a leap year
+                next_year = base.year + 1
+                last_day = calendar.monthrange(next_year, base.month)[1]
+                return base.replace(year=next_year, day=min(base.day, last_day))
             case TaskFrequency.CUSTOM:
                 interval = task.custom_days_interval or 30
                 return base + timedelta(days=interval)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -3,16 +3,27 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.core import CoreState
+
 from custom_components.intellikeep.frontend import async_register_frontend, _async_register_card_resource
 
 
 async def test_async_register_frontend_registers_static_path(mock_hass):
     with patch("custom_components.intellikeep.frontend.ha_frontend.add_extra_js_url") as add_js:
-        with patch("custom_components.intellikeep.frontend.async_call_later"):
-            await async_register_frontend(mock_hass, "intellikeep")
+        await async_register_frontend(mock_hass, "intellikeep")
 
     mock_hass.http.async_register_static_paths.assert_awaited_once()
     add_js.assert_called_once()
+
+
+def _capture_startup_callback(mock_hass):
+    """Make the mock hass defer registration and capture the startup listener."""
+    callbacks = []
+    mock_hass.state = CoreState.not_running
+    mock_hass.bus.async_listen_once = MagicMock(
+        side_effect=lambda _event, cb: callbacks.append(cb)
+    )
+    return callbacks
 
 
 async def test_register_card_resource_creates_resource_when_missing(mock_hass):
@@ -20,14 +31,9 @@ async def test_register_card_resource_creates_resource_when_missing(mock_hass):
     resources.async_get_info = AsyncMock(return_value={"resources": []})
     resources.async_create_item = AsyncMock()
     mock_hass.data["lovelace"] = {"resources": resources}
+    callbacks = _capture_startup_callback(mock_hass)
 
-    callbacks = []
-
-    def capture_later(_hass, _delay, callback):
-        callbacks.append(callback)
-
-    with patch("custom_components.intellikeep.frontend.async_call_later", side_effect=capture_later):
-        _async_register_card_resource(mock_hass, "intellikeep")
+    _async_register_card_resource(mock_hass, "intellikeep")
 
     await callbacks[0](None)
 
@@ -41,15 +47,27 @@ async def test_register_card_resource_skips_duplicate(mock_hass):
     )
     resources.async_create_item = AsyncMock()
     mock_hass.data["lovelace"] = {"resources": resources}
+    callbacks = _capture_startup_callback(mock_hass)
 
-    callbacks = []
-
-    with patch(
-        "custom_components.intellikeep.frontend.async_call_later",
-        side_effect=lambda _hass, _delay, callback: callbacks.append(callback),
-    ):
-        _async_register_card_resource(mock_hass, "intellikeep")
+    _async_register_card_resource(mock_hass, "intellikeep")
 
     await callbacks[0](None)
 
     resources.async_create_item.assert_not_awaited()
+
+
+async def test_register_card_resource_runs_immediately_when_started(mock_hass):
+    resources = MagicMock()
+    resources.async_get_info = AsyncMock(return_value={"resources": []})
+    resources.async_create_item = AsyncMock()
+    mock_hass.data["lovelace"] = {"resources": resources}
+
+    coros = []
+    mock_hass.state = CoreState.running
+    mock_hass.async_create_task = MagicMock(side_effect=coros.append)
+
+    _async_register_card_resource(mock_hass, "intellikeep")
+
+    await coros[0]
+
+    resources.async_create_item.assert_awaited_once()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -111,13 +111,14 @@ class TestSensorEntities:
     ):
         task = make_task(
             name="Replace filter",
-            due_date=datetime.now(timezone.utc) + timedelta(days=1),
+            due_date=datetime.now(timezone.utc) - timedelta(days=2),
             linked_entity_ids=["climate.living_room"],
         )
         runtime_data.coordinator.data = {
             "all_tasks": [task],
             "tasks_due_count": 0,
             "tasks_overdue_count": 1,
+            "overdue_tasks": [task],
             "next_due_task": task,
         }
 
@@ -148,3 +149,28 @@ class TestSensorEntities:
             "linked_entity_ids": ["climate.living_room"],
             "frequency": str(task.frequency),
         }
+
+    async def test_overdue_attribute_omits_non_overdue_tasks(
+        self, mock_hass, mock_config_entry, runtime_data
+    ):
+        task = make_task(
+            name="Due tomorrow",
+            due_date=datetime.now(timezone.utc) + timedelta(days=1),
+        )
+        runtime_data.coordinator.data = {
+            "all_tasks": [task],
+            "tasks_due_count": 0,
+            "tasks_overdue_count": 0,
+            "overdue_tasks": [],
+            "next_due_task": task,
+        }
+
+        added_entities = []
+        await async_setup_entry(
+            mock_hass,
+            mock_config_entry,
+            lambda entities: added_entities.extend(entities),
+        )
+
+        _, overdue_sensor, _ = added_entities
+        assert overdue_sensor.extra_state_attributes is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -155,6 +155,19 @@ class TestRegisteredServices:
         assert tasks[0].notify_days_before == 2
         runtime_data.coordinator.async_refresh.assert_awaited_once()
 
+    async def test_create_task_handler_applies_configured_notify_default(
+        self, registered_service_handlers, runtime_data
+    ):
+        runtime_data.notify_days_before_default = 5
+
+        await registered_service_handlers[SERVICE_CREATE_TASK](
+            MagicMock(data={"name": "Uses default"})
+        )
+
+        tasks = runtime_data.storage.get_all_tasks()
+        assert len(tasks) == 1
+        assert tasks[0].notify_days_before == 5
+
     async def test_complete_delete_update_and_note_handlers_raise_for_missing_tasks(
         self, registered_service_handlers
     ):

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -164,6 +164,11 @@ class TestTaskStatus:
         task = make_task(due_date=datetime.now(timezone.utc) - timedelta(days=3))
         assert task_manager.get_task_status(task) == TaskStatus.OVERDUE
 
+    def test_status_overdue_one_day_after_due(self, task_manager):
+        """A task becomes overdue the day after its due date."""
+        task = make_task(due_date=datetime.now(timezone.utc) - timedelta(days=1))
+        assert task_manager.get_task_status(task) == TaskStatus.OVERDUE
+
     def test_status_completed(self, task_manager):
         task = make_task(enabled=False)
         assert task_manager.get_task_status(task) == TaskStatus.COMPLETED
@@ -211,6 +216,15 @@ class TestFrequencyCalculation:
         task.last_completed_at = datetime(2025, 3, 10)
         next_due = task_manager._calculate_next_due(task)
         assert next_due.year == 2026
+
+    def test_yearly_leap_day(self, task_manager):
+        """Feb 29 → Feb 28 when the next year is not a leap year."""
+        task = make_task(frequency=TaskFrequency.YEARLY)
+        task.last_completed_at = datetime(2024, 2, 29)
+        next_due = task_manager._calculate_next_due(task)
+        assert next_due.year == 2025
+        assert next_due.month == 2
+        assert next_due.day == 28
 
     def test_custom(self, task_manager):
         task = make_task(frequency=TaskFrequency.CUSTOM, custom_days_interval=45)
@@ -279,3 +293,21 @@ class TestQueryMethods:
         mock_storage.upsert_task(disabled)
 
         assert task_manager.get_tasks_approaching_due() == []
+
+
+class TestTaskUpdatedEvent:
+    async def test_mutations_fire_task_updated_event(
+        self, task_manager, mock_storage, mock_hass
+    ):
+        task = await task_manager.async_create_task(name="Evented")
+        await task_manager.async_complete_task(task.task_id)
+        await task_manager.async_delete_task(task.task_id)
+
+        events = [
+            call.args
+            for call in mock_hass.bus.async_fire.call_args_list
+            if call.args[0] == "intellikeep_task_updated"
+        ]
+        actions = [payload["action"] for _, payload in events]
+        assert actions == ["created", "completed", "deleted"]
+        assert all(payload["task_id"] == task.task_id for _, payload in events)


### PR DESCRIPTION
Closes #20

## Summary

Fixes the six backend bugs plus minor cleanups identified in #20, ahead of the HACS default submission:

- **`overdue_tasks` sensor attribute** — the coordinator now exposes the real overdue list and the sensor consumes it, instead of filtering `all_tasks` by "enabled".
- **Feb 29 yearly recurrence crash** — `_calculate_next_due` clamps the day with `calendar.monthrange` for yearly tasks (Feb 29 2024 → Feb 28 2025). The inline `import calendar` in the monthly case moved to module level.
- **Overdue semantics** — a task is now `overdue` the day after its due date (`days_until_due < 0`); the undocumented extra grace day is gone. Overdue notifications and `was_late` marking shift accordingly.
- **`notify_days_before_default` now applied** — the configured value is stored on runtime data and used by `create_task` when the field is omitted (`0` is preserved as a valid value).
- **`intellikeep_task_updated` implemented** — fired by `TaskManager` on every mutation with `task_id` and `action` (`created`, `updated`, `completed`, `reopened`, `deleted`, `note_added`, `note_deleted`).
- **Panel removed on unload** — reloading the entry after an options change re-registers the sidebar panel cleanly instead of failing silently.
- **Cleanups** — dead `async_unregister_services` import, redundant `except (ValueError, Exception)`, unused `os` import, and the Lovelace resource registration now waits for `EVENT_HOMEASSISTANT_STARTED` (registering immediately if HA is already running) instead of a fixed 2s delay.

Also adds an Unreleased section to the changelog and updates CLAUDE.md.

## Test plan

- `./run-tests.sh` — 108 passed, including 6 new tests: overdue status boundary (day after due), Feb 29 yearly rollover, event firing on mutations, overdue attribute filtering (populated and empty), configured notify default applied by the service handler, and immediate card-resource registration when HA is already running.