### PR TITLE
Modernize config-entry handling to current HA patterns

### DIFF
--- a/custom_components/intellikeep/__init__.py
+++ b/custom_components/intellikeep/__init__.py
@@ -49,8 +49,6 @@ async def async_setup(hass: HomeAssistant, config: Mapping[str, Any]) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: IntelliKeepConfigEntry) -> bool:
     """Set up IntelliKeep from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-
     # --- Storage ---
     storage = IntelliKeepStorage(hass)
     await storage.async_load()
@@ -59,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: IntelliKeepConfigEntry) 
     task_manager = TaskManager(hass, storage)
 
     # --- Coordinator ---
-    coordinator = IntelliKeepCoordinator(hass, task_manager)
+    coordinator = IntelliKeepCoordinator(hass, entry, task_manager)
     await coordinator.async_config_entry_first_refresh()
 
     # --- Notifications ---
@@ -85,7 +83,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: IntelliKeepConfigEntry) 
         notify_days_before_default=int(notify_days_before_default),
     )
     entry.runtime_data = runtime_data
-    hass.data[DOMAIN][entry.entry_id] = runtime_data
 
     # --- Frontend: register static path + Lovelace card resource ---
     await async_register_frontend(hass, DOMAIN)
@@ -99,22 +96,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: IntelliKeepConfigEntry) 
     # Reload entry when options are updated
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 
-    _LOGGER.info("IntelliKeep integration loaded (entry: %s)", entry.entry_id)
+    _LOGGER.debug("IntelliKeep integration loaded (entry: %s)", entry.entry_id)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: IntelliKeepConfigEntry) -> bool:
     """Unload IntelliKeep config entry."""
-    # Stop notification manager
-    runtime_data = hass.data[DOMAIN].get(entry.entry_id)
-    notification_manager = runtime_data.notification_manager if runtime_data else None
-    if notification_manager:
-        notification_manager.stop()
+    entry.runtime_data.notification_manager.stop()
 
-    # Unload platforms
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id, None)
         _async_remove_panel(hass)
 
     return unload_ok

--- a/custom_components/intellikeep/config_flow.py
+++ b/custom_components/intellikeep/config_flow.py
@@ -61,7 +61,8 @@ class IntelliKeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
             return self.async_create_entry(
                 title=user_input[CONF_INSTANCE_NAME],
-                data=user_input,
+                data={},
+                options=user_input,
             )
 
         return self.async_show_form(
@@ -82,11 +83,11 @@ class IntelliKeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_update_reload_and_abort(
                 entry,
                 title=user_input[CONF_INSTANCE_NAME],
-                data=user_input,
+                options=user_input,
             )
 
-        current = dict(entry.data)
-        current.update(entry.options)
+        # Merge data for installs created before settings moved to options
+        current = {**entry.data, **entry.options}
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=_build_config_schema(current),
@@ -97,14 +98,11 @@ class IntelliKeepConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(
         config_entry: ConfigEntry,
     ) -> IntelliKeepOptionsFlow:
-        return IntelliKeepOptionsFlow(config_entry)
+        return IntelliKeepOptionsFlow()
 
 
 class IntelliKeepOptionsFlow(config_entries.OptionsFlow):
     """Handle IntelliKeep options (reconfiguration)."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        self._config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict | None = None
@@ -112,7 +110,8 @@ class IntelliKeepOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        current = self._config_entry.options or self._config_entry.data
+        # Merge data for installs created before settings moved to options
+        current = {**self.config_entry.data, **self.config_entry.options}
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/intellikeep/coordinator.py
+++ b/custom_components/intellikeep/coordinator.py
@@ -21,10 +21,16 @@ class IntelliKeepCoordinator(DataUpdateCoordinator[dict]):
 
     config_entry: ConfigEntry
 
-    def __init__(self, hass: HomeAssistant, task_manager: TaskManager) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        task_manager: TaskManager,
+    ) -> None:
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=DOMAIN,
             update_interval=UPDATE_INTERVAL,
         )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -35,8 +35,9 @@ class TestConfigFlow:
 
         assert result["type"] == "create_entry"
         assert result["title"] == "My Home"
-        assert result["data"][CONF_INSTANCE_NAME] == "My Home"
-        assert result["data"][CONF_NOTIFY_DAYS_BEFORE_DEFAULT] == 2
+        assert result["data"] == {}
+        assert result["options"][CONF_INSTANCE_NAME] == "My Home"
+        assert result["options"][CONF_NOTIFY_DAYS_BEFORE_DEFAULT] == 2
         flow.async_set_unique_id.assert_awaited_once_with(DOMAIN)
         flow._abort_if_unique_id_configured.assert_called_once()
 
@@ -67,7 +68,7 @@ class TestConfigFlow:
             }
         )
 
-        assert result["data"][CONF_INSTANCE_NAME] == DEFAULT_INSTANCE_NAME
+        assert result["options"][CONF_INSTANCE_NAME] == DEFAULT_INSTANCE_NAME
 
     async def test_reconfigure_updates_entry(self):
         flow = IntelliKeepConfigFlow()
@@ -93,6 +94,9 @@ class TestConfigFlow:
 
         assert result["reason"] == "reconfigured"
         flow.async_update_reload_and_abort.assert_called_once()
+        kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+        assert kwargs["options"][CONF_NOTIFY_DAYS_BEFORE_DEFAULT] == 3
+        assert "data" not in kwargs
 
     async def test_reconfigure_shows_form(self):
         flow = IntelliKeepConfigFlow()
@@ -123,7 +127,10 @@ class TestOptionsFlow:
         }
         entry.options = {}
 
-        flow = IntelliKeepOptionsFlow(entry)
+        flow = IntelliKeepOptionsFlow()
+        flow.hass = MagicMock()
+        flow.handler = "entry-1"
+        flow.hass.config_entries.async_get_known_entry = MagicMock(return_value=entry)
         result = await flow.async_step_init(
             {
                 CONF_INSTANCE_NAME: "Updated Home",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
 
 from custom_components.intellikeep.coordinator import IntelliKeepCoordinator
 from tests.conftest import make_task
 
 
-async def test_coordinator_aggregates_task_state(mock_hass, task_manager, mock_storage):
+async def test_coordinator_aggregates_task_state(
+    mock_hass, mock_config_entry, task_manager, mock_storage
+):
     due_task = make_task(name="Due", due_date=datetime.now(timezone.utc))
     overdue_task = make_task(
         name="Overdue", due_date=datetime.now(timezone.utc) - timedelta(days=3)
@@ -20,8 +21,7 @@ async def test_coordinator_aggregates_task_state(mock_hass, task_manager, mock_s
     mock_storage.upsert_task(overdue_task)
     mock_storage.upsert_task(later_task)
 
-    with patch("homeassistant.helpers.frame.report_usage"):
-        coordinator = IntelliKeepCoordinator(mock_hass, task_manager)
+    coordinator = IntelliKeepCoordinator(mock_hass, mock_config_entry, task_manager)
 
     result = await coordinator._async_update_data()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,18 +41,14 @@ async def test_async_setup_entry_stores_runtime_data(mock_hass, mock_config_entr
 
     assert result is True
     assert isinstance(mock_config_entry.runtime_data, IntelliKeepRuntimeData)
-    assert mock_hass.data["intellikeep"][mock_config_entry.entry_id] is mock_config_entry.runtime_data
     notification_manager.start.assert_called_once()
     mock_hass.config_entries.async_forward_entry_setups.assert_awaited_once()
 
 
-async def test_async_unload_entry_stops_manager_and_clears_runtime_data(
+async def test_async_unload_entry_stops_notification_manager(
     mock_hass, mock_config_entry, runtime_data
 ):
-    mock_hass.data["intellikeep"] = {mock_config_entry.entry_id: runtime_data}
-
     result = await async_unload_entry(mock_hass, mock_config_entry)
 
     assert result is True
     runtime_data.notification_manager.stop.assert_called_once()
-    assert mock_hass.data["intellikeep"] == {}


### PR DESCRIPTION
Closes #22

## Summary

- **Runtime data single-sourced** — runtime objects live only on `entry.runtime_data`; the `hass.data[DOMAIN][entry_id]` duplication is gone and `async_unload_entry` reads from the entry.
- **Coordinator receives the config entry** — `IntelliKeepCoordinator(hass, entry, task_manager)` passes `config_entry` to `DataUpdateCoordinator.__init__`, removing the deprecation path (the coordinator test no longer needs to patch `homeassistant.helpers.frame.report_usage`).
- **Modern OptionsFlow** — no stored entry in `__init__`; uses the framework-provided `self.config_entry`.
- **Single write target for settings** — user step creates the entry with `data={}, options=user_input`; reconfigure and the options flow also write to `options`. Reads keep a `data` fallback so existing installs keep working without migration.
- Entry setup log downgraded from `info` to `debug` per HA logging guidelines.

## Test plan

- `./run-tests.sh` — 108 passed. Updated: config flow asserts entry `data`/`options` split and reconfigure writing `options`; options flow test wires the framework `config_entry` lookup; coordinator test constructs with the entry and drops the frame patch; init tests no longer reference `hass.data`.