### PR TITLE
Encapsulate storage/notification internals; register delete_all_data as admin service

### DIFF
--- a/custom_components/intellikeep/coordinator.py
+++ b/custom_components/intellikeep/coordinator.py
@@ -32,7 +32,7 @@ class IntelliKeepCoordinator(DataUpdateCoordinator[dict]):
 
     async def _async_update_data(self) -> dict:
         """Aggregate task stats for sensor entities."""
-        all_tasks = self.task_manager._storage.get_all_tasks()
+        all_tasks = self.task_manager.get_all_tasks()
         overdue_tasks = self.task_manager.get_overdue_tasks()
         return {
             "all_tasks": all_tasks,

--- a/custom_components/intellikeep/notifications.py
+++ b/custom_components/intellikeep/notifications.py
@@ -52,6 +52,11 @@ class NotificationManager:
         self._notified_approaching.discard(task_id)
         self._notified_overdue.discard(task_id)
 
+    def reset(self) -> None:
+        """Clear all notification deduplication state."""
+        self._notified_approaching.clear()
+        self._notified_overdue.clear()
+
     async def _async_check_notifications(self, _now: datetime) -> None:
         await self._notify_approaching_tasks()
         await self._notify_overdue_tasks()

--- a/custom_components/intellikeep/services.py
+++ b/custom_components/intellikeep/services.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.service import async_register_admin_service
 
 from .const import (
     DOMAIN,
@@ -102,10 +103,7 @@ def async_register_services(
         from .seed import build_sample_tasks  # noqa: PLC0415
 
         tasks = build_sample_tasks()
-        for task in tasks:
-            task.task_number = task_manager._storage.next_task_number()
-            task_manager._storage.upsert_task(task)
-        await task_manager._storage.async_save()
+        await task_manager.async_add_tasks(tasks)
         await coordinator.async_refresh()
         _LOGGER.info("IntelliKeep sample data loaded (%d tasks)", len(tasks))
 
@@ -200,10 +198,8 @@ def async_register_services(
         runtime_data = _get_runtime_data(hass)
         task_manager = runtime_data.task_manager
         coordinator = runtime_data.coordinator
-        count = task_manager._storage.clear_all_tasks()
-        await task_manager._storage.async_save()
-        runtime_data.notification_manager._notified_approaching.clear()
-        runtime_data.notification_manager._notified_overdue.clear()
+        count = await task_manager.async_delete_all_tasks()
+        runtime_data.notification_manager.reset()
         await coordinator.async_refresh()
         _LOGGER.info("IntelliKeep: deleted all data (%d tasks removed)", count)
 
@@ -215,7 +211,10 @@ def async_register_services(
     hass.services.async_register(DOMAIN, SERVICE_UPDATE_TASK, handle_update_task)
     hass.services.async_register(DOMAIN, SERVICE_ADD_TASK_NOTE, handle_add_task_note)
     hass.services.async_register(DOMAIN, SERVICE_DELETE_TASK_NOTE, handle_delete_task_note)
-    hass.services.async_register(DOMAIN, SERVICE_DELETE_ALL_DATA, handle_delete_all_data)
+    # Destructive: only admins may wipe all data
+    async_register_admin_service(
+        hass, DOMAIN, SERVICE_DELETE_ALL_DATA, handle_delete_all_data
+    )
     _LOGGER.debug("IntelliKeep services registered")
 
 

--- a/custom_components/intellikeep/task_manager.py
+++ b/custom_components/intellikeep/task_manager.py
@@ -268,9 +268,30 @@ class TaskManager:
             _LOGGER.debug("Deleted task %s", task_id)
         return deleted
 
+    async def async_add_tasks(self, tasks: list[Task]) -> None:
+        """Bulk-insert tasks, assigning sequential task numbers."""
+        for task in tasks:
+            task.task_number = self._storage.next_task_number()
+            self._storage.upsert_task(task)
+        await self._storage.async_save()
+        _LOGGER.debug("Bulk-added %d tasks", len(tasks))
+
+    async def async_delete_all_tasks(self) -> int:
+        """Delete every task and return how many were removed."""
+        count = self._storage.clear_all_tasks()
+        await self._storage.async_save()
+        _LOGGER.debug("Deleted all tasks (%d removed)", count)
+        return count
+
     # ------------------------------------------------------------------
     # Queries
     # ------------------------------------------------------------------
+
+    def get_task(self, task_id: str) -> Task | None:
+        return self._storage.get_task(task_id)
+
+    def get_all_tasks(self) -> list[Task]:
+        return self._storage.get_all_tasks()
 
     def get_task_status(self, task: Task) -> TaskStatus:
         if not task.enabled:

--- a/custom_components/intellikeep/websocket_api.py
+++ b/custom_components/intellikeep/websocket_api.py
@@ -60,7 +60,7 @@ def async_register_websocket_commands(
     ) -> None:
         runtime_data = _get_runtime_data(hass)
         task_manager = runtime_data.task_manager
-        task = runtime_data.storage.get_task(msg["task_id"])
+        task = task_manager.get_task(msg["task_id"])
         if task is None:
             connection.send_error(msg["id"], "not_found", f"Task {msg['task_id']} not found")
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,8 @@ def mock_hass():
     hass.services.async_register = MagicMock()
     hass.services.async_remove = MagicMock()
     hass.services.has_service = MagicMock(return_value=False)
+    # Execute HassJob targets directly (used by async_register_admin_service)
+    hass.async_run_hass_job = MagicMock(side_effect=lambda job, *args: job.target(*args))
     hass.bus = MagicMock()
     hass.bus.async_fire = MagicMock()
     hass.config_entries = MagicMock()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -16,6 +16,16 @@ def notification_manager(mock_hass, task_manager):
     return mgr
 
 
+def test_reset_clears_dedup_state(notification_manager):
+    notification_manager._notified_approaching.add("task-a")
+    notification_manager._notified_overdue.add("task-b")
+
+    notification_manager.reset()
+
+    assert notification_manager._notified_approaching == set()
+    assert notification_manager._notified_overdue == set()
+
+
 class TestApproachingNotifications:
     async def test_notifies_approaching_task(
         self, notification_manager, mock_hass, task_manager, mock_storage

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.exceptions import ServiceValidationError
@@ -208,19 +208,32 @@ class TestRegisteredServices:
         assert len(runtime_data.storage.get_all_tasks()) > 1
         runtime_data.coordinator.async_refresh.assert_awaited_once()
 
-    async def test_delete_all_data_clears_tasks_and_notification_sets(
+    async def test_delete_all_data_clears_tasks_and_resets_notifications(
         self, registered_service_handlers, runtime_data
     ):
         task = make_task()
         runtime_data.storage.upsert_task(task)
-        runtime_data.notification_manager._notified_approaching = {task.task_id}
-        runtime_data.notification_manager._notified_overdue = {task.task_id}
 
-        await registered_service_handlers[SERVICE_DELETE_ALL_DATA](MagicMock(data={}))
+        await registered_service_handlers[SERVICE_DELETE_ALL_DATA](
+            MagicMock(data={}, context=MagicMock(user_id=None))
+        )
 
         assert runtime_data.storage.get_all_tasks() == []
-        assert runtime_data.notification_manager._notified_approaching == set()
-        assert runtime_data.notification_manager._notified_overdue == set()
+        runtime_data.notification_manager.reset.assert_called_once()
+
+    async def test_delete_all_data_rejects_non_admin(
+        self, registered_service_handlers, mock_hass
+    ):
+        from homeassistant.exceptions import Unauthorized
+
+        mock_hass.auth.async_get_user = AsyncMock(
+            return_value=MagicMock(is_admin=False)
+        )
+
+        with pytest.raises(Unauthorized):
+            await registered_service_handlers[SERVICE_DELETE_ALL_DATA](
+                MagicMock(data={}, context=MagicMock(user_id="user-1"))
+            )
 
     def test_unregister_services_removes_all(self, mock_hass):
         async_unregister_services(mock_hass)

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -295,6 +295,23 @@ class TestQueryMethods:
         assert task_manager.get_tasks_approaching_due() == []
 
 
+class TestBulkOperations:
+    async def test_add_tasks_assigns_sequential_numbers(self, task_manager, mock_storage):
+        await task_manager.async_add_tasks([make_task(name="A"), make_task(name="B")])
+
+        numbers = [t.task_number for t in task_manager.get_all_tasks()]
+        assert numbers == [1, 2]
+
+    async def test_delete_all_tasks_returns_count(self, task_manager, mock_storage):
+        mock_storage.upsert_task(make_task(name="One"))
+        mock_storage.upsert_task(make_task(name="Two"))
+
+        count = await task_manager.async_delete_all_tasks()
+
+        assert count == 2
+        assert task_manager.get_all_tasks() == []
+
+
 class TestTaskUpdatedEvent:
     async def test_mutations_fire_task_updated_event(
         self, task_manager, mock_storage, mock_hass


### PR DESCRIPTION
Closes #23

## Summary

- **`TaskManager` public API** — new `get_task`, `get_all_tasks`, `async_add_tasks` (bulk insert with sequential task numbers) and `async_delete_all_tasks` methods. `services.py`, `coordinator.py` and `websocket_api.py` now use them instead of reaching into the private `_storage`.
- **`NotificationManager.reset()`** — the `delete_all_data` handler no longer clears the private dedup sets directly.
- **`delete_all_data` is admin-only** — registered via `async_register_admin_service`; non-admin users get `Unauthorized`.

## Test plan

- `./run-tests.sh` — 112 passed. New tests: bulk insert assigns sequential numbers, delete-all returns the removed count, `reset()` clears dedup state, and the admin wrapper rejects non-admin users. The mock `hass` in `conftest.py` now executes `HassJob` targets so the admin-service wrapper runs in unit tests.