### PR TITLE
Register Lovelace card in the card picker and document YAML-mode resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ show_linked_entities: true
 show_description: false
 ```
 
+> **YAML-mode dashboards**: the card resource is registered automatically only when dashboards are managed via the UI (storage mode). If your dashboards are configured in YAML, add the resource manually:
+>
+> ```yaml
+> resources:
+>   - url: /intellikeep_static/intellikeep-card.js
+>     type: module
+> ```
+
 ### Panel views
 
 | View | Description |

--- a/custom_components/intellikeep/frontend/intellikeep-card.js
+++ b/custom_components/intellikeep/frontend/intellikeep-card.js
@@ -499,5 +499,13 @@ __decorate([
 IntelliKeepCard = __decorate([
     t("intellikeep-card")
 ], IntelliKeepCard);
+// Register in the Lovelace card picker
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: "intellikeep-card",
+    name: "IntelliKeep Card",
+    description: "Compact list of due and overdue IntelliKeep tasks.",
+    documentationURL: "https://github.com/henriquekraemer/intellikeep",
+});
 
 export { IntelliKeepCard };

--- a/custom_components/intellikeep/frontend/lovelace-card/dist/intellikeep-card.d.ts
+++ b/custom_components/intellikeep/frontend/lovelace-card/dist/intellikeep-card.d.ts
@@ -31,4 +31,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "intellikeep-card": IntelliKeepCard;
     }
+    interface Window {
+        customCards?: object[];
+    }
 }

--- a/lovelace-card/src/intellikeep-card.ts
+++ b/lovelace-card/src/intellikeep-card.ts
@@ -258,4 +258,16 @@ declare global {
   interface HTMLElementTagNameMap {
     "intellikeep-card": IntelliKeepCard;
   }
+  interface Window {
+    customCards?: object[];
+  }
 }
+
+// Register in the Lovelace card picker
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: "intellikeep-card",
+  name: "IntelliKeep Card",
+  description: "Compact list of due and overdue IntelliKeep tasks.",
+  documentationURL: "https://github.com/henriquekraemer/intellikeep",
+});


### PR DESCRIPTION
Closes #24

## Summary

- The card now pushes itself to `window.customCards`, so it appears in the Lovelace card picker with a proper name, description and documentation link (it already had `getConfigElement`/`getStubConfig` for the visual editor, but was invisible in the picker).
- README documents the manual resource step for YAML-mode dashboards, since the automatic Lovelace resource registration only works in storage mode.
- Card bundle rebuilt via `./build-frontend.sh card` (verified `window.customCards` present in the committed bundle).

## Test plan

- Docker build of the card succeeds; `customCards` registration confirmed in `custom_components/intellikeep/frontend/intellikeep-card.js`.
- Backend untouched — pytest suite unaffected.